### PR TITLE
Make hint/BS snippets strict compliant.

### DIFF
--- a/DB_File_BS
+++ b/DB_File_BS
@@ -1,4 +1,5 @@
 # NeXT needs /usr/lib/libposix.a to load along with DB_File.so
+no strict 'vars';
 if ( $dlsrc eq "dl_next.xs" ) {
     @DynaLoader::dl_resolve_using = ( '/usr/lib/libposix.a' );
 }

--- a/hints/bitrig.pl
+++ b/hints/bitrig.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/hints/dynixptx.pl
+++ b/hints/dynixptx.pl
@@ -1,3 +1,3 @@
 # Need to add an extra '-lc' to the end to work around a DYNIX/ptx bug
-
+no strict 'vars';
 $self->{LIBS} = ['-lm -lc'];

--- a/hints/minix.pl
+++ b/hints/minix.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/hints/netbsd.pl
+++ b/hints/netbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/hints/openbsd.pl
+++ b/hints/openbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/hints/sco.pl
+++ b/hints/sco.pl
@@ -1,2 +1,3 @@
 # osr5 needs to explicitly link against libc to pull in some static symbols
+no strict 'vars';
 $self->{LIBS} = ['-ldb -lc'] if $Config{'osvers'} =~ '3\.2v5\.0\..' ;


### PR DESCRIPTION
Explicitly disable strict vars so the snippets when loaded in
from a strict scope work correctly.