### PR TITLE
Stop shipping DB_File_BS for the NeXT operating system (RIP)

### DIFF
--- a/DB_File_BS
+++ b/DB_File_BS
@@ -1,7 +1,0 @@
-# NeXT needs /usr/lib/libposix.a to load along with DB_File.so
-no strict 'vars';
-if ( $dlsrc eq "dl_next.xs" ) {
-    @DynaLoader::dl_resolve_using = ( '/usr/lib/libposix.a' );
-}
-
-1;

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,7 +1,6 @@
 Changes
 DB_File.pm          
 DB_File.xs          
-DB_File_BS
 MANIFEST
 Makefile.PL         
 README


### PR DESCRIPTION
DB_File_BS was only needed for NeXT systems which no longer exist and
hasn't even been supported by Perl in 5 years.