### PR TITLE
Ensure that all *.bak files are cleaned up

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -72,7 +72,7 @@ WriteMakefile(
         #OPTIMIZE       => '-g',
         'depend'        => { 'Makefile'          => 'config.in',
                              'version$(OBJ_EXT)' => 'version.c'},
-        'clean'         => { FILES => 'constants.h constants.xs DB_File.pm.bak t/db-btree.t.bak t/db-hash.t.bak t/db-recno.t.bak t/pod.t.bak' },
+        'clean'         => { FILES => 'constants.h constants.xs *.bak t/*.t.bak' },
         'macro'         => { my_files => "@files" },
         'dist'          => { COMPRESS => 'gzip', SUFFIX => 'gz',
                              DIST_DEFAULT => 'MyDoubleCheck tardist'},


### PR DESCRIPTION
After 'make test' there are 9 '*.bak' files in the tree:

    $ find . -type f -name '*.bak'
    ./t/000prereq.t.bak
    ./t/pod.t.bak
    ./t/meta-json.t.bak
    ./t/meta-yaml.t.bak
    ./t/db-threads.t.bak
    ./t/db-hash.t.bak
    ./t/db-recno.t.bak
    ./t/db-btree.t.bak
    ./DB_File.pm.bak

However, 'make clean' was only cleaning up 5 of them, leaving:

    ./t/000prereq.t.bak
    ./t/meta-json.t.bak
    ./t/meta-yaml.t.bak
    ./t/db-threads.t.bak

Better to use shell globs in the Makefile than hard-coding each name.

In the Perl 5 core distribution, cpan/DB_File/t/db-threads.t.bak was the
only file not being cleaned up via 'make clean'.